### PR TITLE
application.rb で各種設定を変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,22 @@ module QiitaClone
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.template_engine false
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.test_framework :rspec,
+                       fixtures: true,
+                       fixture_replacement: :factory_bot,
+                       view_specs: false,
+                       routing_specs: false,
+                       helper_specs: false,
+                       controller_specs: false,
+                       request_specs: true
+    end
+
+    config.api_only = true
   end
 end


### PR DESCRIPTION
## 補足
本 PR の内容のうち、 `fixture_replacement: :factory_bot,` はなくても動きます。
以下で OK です。

```rb
config.generators do |g|
  g.template_engine false
  g.javascripts false
  g.stylesheets false
  g.helper true
  g.test_framework :rspec,
                   view_specs: false,
                   routing_specs: false,
                   helper_specs: false,
                   controller_specs: false,
                   request_specs: true
end
```

https://github.com/mc-chinju/qiita_clone/pull/17

## 概要
 - `rails generate` を始めとする設定を変更

## 関連
https://github.com/mc-chinju/qiita_clone/issues/5