### PR TITLE
rails generate コマンドの設定ファイルの作成

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,21 +30,6 @@ module QiitaClone
     # Don't generate system test files.
     config.generators.system_tests = nil
 
-    config.generators do |g|
-      g.template_engine false
-      g.javascripts false
-      g.stylesheets false
-      g.helper false
-      g.test_framework :rspec,
-                       fixtures: true,
-                       fixture_replacement: :factory_bot,
-                       view_specs: false,
-                       routing_specs: false,
-                       helper_specs: false,
-                       controller_specs: false,
-                       request_specs: true
-    end
-
     config.api_only = true
   end
 end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,13 @@
+Rails.application.config.generators do |g|
+  g.template_engine false
+  g.javascripts false
+  g.stylesheets false
+  g.helper true
+  g.factory_bot dir: "spec/factories"
+  g.test_framework :rspec,
+                   view_specs: false,
+                   routing_specs: false,
+                   helper_specs: false,
+                   controller_specs: false,
+                   request_specs: true
+end


### PR DESCRIPTION
## 概要
 - `rails generate` コマンドの設定を application.rb から config/initializers/generate.rb に移動
 - 設定内容を最新の状態に変更

## 関連
https://github.com/mc-chinju/qiita_clone/pull/17