### PR TITLE
Articles Read に関する API およびテストの実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,40 @@
+module Api::V1
+  class ArticlesController < BaseApiController
+    before_action :set_article, only: [:show]
+    # before_action :set_article, only: [:show, :update, :destroy]
+
+    def index
+      articles = Article.all
+      render json: articles
+    end
+
+    def show
+      render json: @article
+    end
+
+    # def create
+    #   article = Article.create!(article_params)
+    #   render json: article
+    # end
+
+    # def update
+    #   @article.update!(article_params)
+    #   render json: @article
+    # end
+
+    # def destroy
+    #   @article.destroy!
+    #   render json: @article
+    # end
+
+    private
+
+      def set_article
+        @article = Article.find(params[:id])
+      end
+
+    # def article_params
+    #   params.require(:article).permit(:title, :body)
+    # end
+  end
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::BaseApiController < ApplicationController
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-  include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,4 +13,5 @@
 class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  belongs_to :user
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body
+  belongs_to :user
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,3 @@
+ActiveModelSerializers.config do |config|
+  config.adapter = :json_api
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api, format: :json do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+    end
+  end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -22,7 +22,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 8
+  Enabled: false
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :article do
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentences }
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    provider { "email" }
+    name { Faker::Name.name }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password }
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  describe "GET /articles" do
+    it "works! (now write some real specs)" do
+      get api_v1_articles_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe "Articles", type: :request do
       end
     end
   end
+
+  describe "GET /users/:id" do
+    subject { get(api_v1_article_path(article_id)) }
+
+    context "指定した id のユーザーが存在する場合" do
+      let(:article) { create(:article) }
+      let(:article_id) { article.id }
+
+      it "任意のユーザーの値が取得できる" do
+        subject
+
+        res = JSON.parse(response.body)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -2,9 +2,21 @@ require "rails_helper"
 
 RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
-    it "works! (now write some real specs)" do
-      get api_v1_articles_path
-      expect(response).to have_http_status(:ok)
+    subject { get(api_v1_articles_path) }
+
+    before { create_list(:article, 3) }
+
+    it "記事の一覧が取得できる" do
+      subject
+
+      res = JSON.parse(response.body)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res[0].keys).to eq ["id", "title", "body", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
 - ルーティングを `/api/v1` 配下に移動
 - Articles API の実装（index, show の2つ、つまり Read に該当する部分のみ）
 - Articles API のテストの実装
