### PR TITLE
トップページとユーザー登録まわりのページのデザインを修正

### DIFF
--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -1,4 +1,4 @@
-import Vue from "vue/dist/vue.esm";
+import Vue from "vue";
 import Router from "./router/router";
 import Header from "./container/Header.vue";
 

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -1,9 +1,13 @@
 import Vue from "vue/dist/vue.esm";
 import Router from "./router/router";
+import Header from "./container/Header.vue";
 
 document.addEventListener("turbolinks:load", () => {
   new Vue({
     el: "#app",
-    router: Router
+    router: Router,
+    components: {
+      navbar: Header
+    }
   });
 });

--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -1,6 +1,9 @@
 import Vue from "vue";
 import Router from "./router/router";
 import Header from "./container/Header.vue";
+import Vuetify from "vuetify";
+
+Vue.use(Vuetify);
 
 document.addEventListener("turbolinks:load", () => {
   new Vue({

--- a/app/javascript/packs/container/ArticlesContainer.vue
+++ b/app/javascript/packs/container/ArticlesContainer.vue
@@ -15,7 +15,7 @@ import { Vue, Component } from "vue-property-decorator";
 
 @Component
 export default class ArticlesContainer extends Vue {
-  articles: String[] = [];
+  articles: string[] = [];
 
   async mounted(): Promise<void> {
     await this.fetchArticles();

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -10,7 +10,7 @@
 
     <v-spacer></v-spacer>
 
-    <router-link to="/" class="header-link">
+    <router-link to="/sign_up" class="header-link">
       <v-btn flat class="register">ユーザー登録</v-btn>
     </router-link>
     <router-link to="/" class="header-link">

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>へっだー</div>
+</template>

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -20,7 +20,7 @@
       <router-link to="/sign_up" class="header-link">
         <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
       </router-link>
-      <router-link to="/" class="header-link">
+      <router-link to="/sign_in" class="header-link">
         <v-btn flat class="font-weight-bold">ログイン</v-btn>
       </router-link>
     </div>

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -1,7 +1,7 @@
 <template>
   <v-toolbar dark color="#55c500">
     <router-link to="/" class="header-link">
-      <v-toolbar-title class="white--text">Qiita</v-toolbar-title>
+      <v-toolbar-title class="white--text font-weight-bold">Qiita</v-toolbar-title>
     </router-link>
 
     <!-- <v-btn icon>
@@ -10,21 +10,74 @@
 
     <v-spacer></v-spacer>
 
-    <router-link to="/sign_up" class="header-link">
-      <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
-    </router-link>
-    <router-link to="/" class="header-link">
-      <v-btn flat class="font-weight-bold">ログイン</v-btn>
-    </router-link>
+    <div v-if="isLoggedIn">
+      <router-link to="/articles/new" class="header-link">
+        <v-btn flat class="post font-weight-bold">投稿する</v-btn>
+      </router-link>
+      <v-btn flat @click="logout" class="white--text font-weight-bold">ログアウト</v-btn>
+    </div>
+    <div v-else>
+      <router-link to="/sign_up" class="header-link">
+        <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
+      </router-link>
+      <router-link to="/" class="header-link">
+        <v-btn flat class="font-weight-bold">ログイン</v-btn>
+      </router-link>
+    </div>
   </v-toolbar>
 </template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import Router from "../router/router";
+
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+
+@Component
+export default class Header extends Vue {
+  isLoggedIn: boolean = !!localStorage.getItem("access-token");
+
+  async logout(): Promise<void> {
+    await axios
+      .delete("/api/v1/auth/sign_out", headers)
+      .then(_response => {
+        this.refresh();
+      })
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.data.errors);
+
+        // localStorage は残っているが、
+        // ログアウトはしてしまっている状態なのですべてリセットする
+        this.refresh();
+      });
+  }
+
+  private refresh(): void {
+    localStorage.clear();
+    Router.push("/");
+    // TODO: Vuex でログイン状態を管理するようになったら消す
+    window.location.reload();
+  }
+}
+</script>
 
 <style lang="scss" scoped>
 .header-link {
   text-decoration: none;
 }
 
-.register {
+.register,
+.post {
   border: 2px solid #fff;
   border-radius: 5px;
 }

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -1,3 +1,36 @@
 <template>
-  <div>へっだー</div>
+  <v-toolbar dark color="#55c500">
+    <router-link to="/" class="header-link">
+      <v-toolbar-title class="white--text">Qiita</v-toolbar-title>
+    </router-link>
+
+    <!-- <v-btn icon>
+      <v-icon>search</v-icon>
+    </v-btn>-->
+
+    <v-spacer></v-spacer>
+
+    <router-link to="/" class="header-link">
+      <v-btn flat class="register">ユーザー登録</v-btn>
+    </router-link>
+    <router-link to="/" class="header-link">
+      <v-btn flat class="login">ログイン</v-btn>
+    </router-link>
+  </v-toolbar>
 </template>
+
+<style lang="scss" scoped>
+.header-link {
+  text-decoration: none;
+}
+
+.register {
+  border: 2px solid #fff;
+  border-radius: 5px;
+  font-weight: bold;
+}
+
+.login {
+  font-weight: bold;
+}
+</style>

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -11,10 +11,10 @@
     <v-spacer></v-spacer>
 
     <router-link to="/sign_up" class="header-link">
-      <v-btn flat class="register">ユーザー登録</v-btn>
+      <v-btn flat class="register font-weight-bold">ユーザー登録</v-btn>
     </router-link>
     <router-link to="/" class="header-link">
-      <v-btn flat class="login">ログイン</v-btn>
+      <v-btn flat class="font-weight-bold">ログイン</v-btn>
     </router-link>
   </v-toolbar>
 </template>
@@ -27,7 +27,6 @@
 .register {
   border: 2px solid #fff;
   border-radius: 5px;
-  font-weight: bold;
 }
 
 .login {

--- a/app/javascript/packs/container/LoginContainer.vue
+++ b/app/javascript/packs/container/LoginContainer.vue
@@ -1,0 +1,84 @@
+<template>
+  <form>
+    <v-text-field
+      v-model="email"
+      v-validate="'required|email'"
+      :error-messages="errors.collect('email')"
+      label="メールアドレス"
+      data-vv-name="email"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="password"
+      :append-icon="show ? 'visibility' : 'visibility_off'"
+      :type="show ? 'text' : 'password'"
+      v-validate="'required|min:8|max:50'"
+      :error-messages="errors.collect('password')"
+      name="password"
+      label="パスワード"
+      hint="At least 8 characters"
+      counter
+      @click:append="show = !show"
+    ></v-text-field>
+
+    <v-btn @click="submit" color="#55c500" class="white--text font-weight-bold">ログイン</v-btn>
+  </form>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import VeeValidate from "vee-validate";
+import Router from "../router/router";
+
+Vue.use(VeeValidate, { locale: "ja" });
+
+@Component
+export default class RegisterContainer extends Vue {
+  $_veeValidate: {
+    validator: "new";
+  };
+
+  email: string = "";
+  show: boolean = false;
+  password: string = "";
+  dictionary: {
+    attributes: {
+      email: "Email Addresss";
+    };
+  };
+
+  mounted() {
+    this.$validator.localize("ja", this.dictionary);
+  }
+
+  async submit(): Promise<void> {
+    // this.$validator.validateAll();
+
+    const params = {
+      email: this.email,
+      password: this.password
+    };
+
+    await axios
+      .post("/api/v1/auth/sign_in", params)
+      .then(response => {
+        localStorage.setItem("access-token", response.headers["access-token"]);
+        localStorage.setItem("uid", response.headers["uid"]);
+        localStorage.setItem("client", response.headers["client"]);
+
+        Router.push("/");
+
+        // TODO: Vuex でログイン状態を管理するようになったら消す
+        window.location.reload();
+      })
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.data.errors.full_messages);
+      });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/app/javascript/packs/container/RegisterContainer.vue
+++ b/app/javascript/packs/container/RegisterContainer.vue
@@ -35,8 +35,10 @@
 </template>
 
 <script lang="ts">
+import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import VeeValidate from "vee-validate";
+import Router from "../router/router";
 
 Vue.use(VeeValidate, { locale: "ja" });
 
@@ -66,14 +68,29 @@ export default class RegisterContainer extends Vue {
     this.$validator.localize("en", this.dictionary);
   }
 
-  submit() {
+  async submit(): Promise<void> {
     this.$validator.validateAll();
+    const params = {
+      name: this.name,
+      email: this.email,
+      password: this.password
+    };
+
+    await axios
+      .post("/api/v1/auth", params)
+      .then(_response => {
+        Router.push("/");
+      })
+      .catch(error => {
+        alert(error);
+      });
   }
-  clear() {
-    this.name = "";
-    this.email = "";
-    this.$validator.reset();
-  }
+  // clear() {
+  //   this.name = "";
+  //   this.email = "";
+  //   this.password = "";
+  //   this.$validator.reset();
+  // }
 }
 </script>
 

--- a/app/javascript/packs/container/RegisterContainer.vue
+++ b/app/javascript/packs/container/RegisterContainer.vue
@@ -1,0 +1,81 @@
+<template>
+  <form>
+    <v-text-field
+      v-model="name"
+      v-validate="'required|max:10'"
+      :counter="10"
+      :error-messages="errors.collect('name')"
+      label="Name"
+      data-vv-name="name"
+      required
+    ></v-text-field>
+    <v-text-field
+      v-model="email"
+      v-validate="'required|email'"
+      :error-messages="errors.collect('email')"
+      label="E-mail"
+      data-vv-name="email"
+      required
+    ></v-text-field>
+
+    <v-btn @click="submit">submit</v-btn>
+    <v-btn @click="clear">clear</v-btn>
+  </form>
+</template>
+
+<script>
+import Vue from "vue";
+import VeeValidate from "vee-validate";
+
+Vue.use(VeeValidate);
+
+export default {
+  $_veeValidate: {
+    validator: "new"
+  },
+
+  data: () => ({
+    name: "",
+    email: "",
+    select: null,
+    items: ["Item 1", "Item 2", "Item 3", "Item 4"],
+    checkbox: null,
+    dictionary: {
+      attributes: {
+        email: "E-mail Address"
+        // custom attributes
+      },
+      custom: {
+        name: {
+          required: () => "Name can not be empty",
+          max: "The name field may not be greater than 10 characters"
+          // custom messages
+        },
+        select: {
+          required: "Select field is required"
+        }
+      }
+    }
+  }),
+
+  mounted() {
+    this.$validator.localize("en", this.dictionary);
+  },
+
+  methods: {
+    submit() {
+      this.$validator.validateAll();
+    },
+    clear() {
+      this.name = "";
+      this.email = "";
+      this.select = null;
+      this.checkbox = null;
+      this.$validator.reset();
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/app/javascript/packs/container/RegisterContainer.vue
+++ b/app/javascript/packs/container/RegisterContainer.vue
@@ -65,11 +65,12 @@ export default class RegisterContainer extends Vue {
   };
 
   mounted() {
-    this.$validator.localize("en", this.dictionary);
+    this.$validator.localize("ja", this.dictionary);
   }
 
   async submit(): Promise<void> {
-    this.$validator.validateAll();
+    // this.$validator.validateAll();
+
     const params = {
       name: this.name,
       email: this.email,
@@ -78,11 +79,19 @@ export default class RegisterContainer extends Vue {
 
     await axios
       .post("/api/v1/auth", params)
-      .then(_response => {
+      .then(response => {
+        localStorage.setItem("access-token", response.headers["access-token"]);
+        localStorage.setItem("uid", response.headers["uid"]);
+        localStorage.setItem("client", response.headers["client"]);
+
         Router.push("/");
+
+        // TODO: Vuex でログイン状態を管理するようになったら消す
+        window.location.reload();
       })
-      .catch(error => {
-        alert(error);
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.data.errors.full_messages);
       });
   }
   // clear() {

--- a/app/javascript/packs/container/RegisterContainer.vue
+++ b/app/javascript/packs/container/RegisterContainer.vue
@@ -5,7 +5,7 @@
       v-validate="'required|max:10'"
       :counter="10"
       :error-messages="errors.collect('name')"
-      label="Name"
+      label="ユーザー名"
       data-vv-name="name"
       required
     ></v-text-field>
@@ -13,68 +13,68 @@
       v-model="email"
       v-validate="'required|email'"
       :error-messages="errors.collect('email')"
-      label="E-mail"
+      label="メールアドレス"
       data-vv-name="email"
       required
     ></v-text-field>
+    <v-text-field
+      v-model="password"
+      :append-icon="show ? 'visibility' : 'visibility_off'"
+      :type="show ? 'text' : 'password'"
+      v-validate="'required|min:8|max:50'"
+      :error-messages="errors.collect('password')"
+      name="password"
+      label="パスワード"
+      hint="At least 8 characters"
+      counter
+      @click:append="show = !show"
+    ></v-text-field>
 
-    <v-btn @click="submit">submit</v-btn>
-    <v-btn @click="clear">clear</v-btn>
+    <v-btn @click="submit" color="#55c500" class="white--text font-weight-bold">登録</v-btn>
   </form>
 </template>
 
-<script>
-import Vue from "vue";
+<script lang="ts">
+import { Vue, Component } from "vue-property-decorator";
 import VeeValidate from "vee-validate";
 
-Vue.use(VeeValidate);
+Vue.use(VeeValidate, { locale: "ja" });
 
-export default {
+@Component
+export default class RegisterContainer extends Vue {
   $_veeValidate: {
-    validator: "new"
-  },
+    validator: "new";
+  };
 
-  data: () => ({
-    name: "",
-    email: "",
-    select: null,
-    items: ["Item 1", "Item 2", "Item 3", "Item 4"],
-    checkbox: null,
-    dictionary: {
-      attributes: {
-        email: "E-mail Address"
-        // custom attributes
-      },
-      custom: {
-        name: {
-          required: () => "Name can not be empty",
-          max: "The name field may not be greater than 10 characters"
-          // custom messages
-        },
-        select: {
-          required: "Select field is required"
-        }
-      }
-    }
-  }),
+  name: string = "";
+  email: string = "";
+  show: boolean = false;
+  password: string = "";
+  dictionary: {
+    attributes: {
+      email: "Email Addresss";
+    };
+    custom: {
+      name: {
+        required: () => "Name can not be empty";
+        max: "The name field may not be greater than 10 characters";
+      };
+    };
+  };
 
   mounted() {
     this.$validator.localize("en", this.dictionary);
-  },
-
-  methods: {
-    submit() {
-      this.$validator.validateAll();
-    },
-    clear() {
-      this.name = "";
-      this.email = "";
-      this.select = null;
-      this.checkbox = null;
-      this.$validator.reset();
-    }
   }
-};
+
+  submit() {
+    this.$validator.validateAll();
+  }
+  clear() {
+    this.name = "";
+    this.email = "";
+    this.$validator.reset();
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -2,6 +2,7 @@ import Vue from "vue/dist/vue.esm.js";
 import VueRouter from "vue-router";
 import ArticlesContainer from "../container/ArticlesContainer.vue";
 import RegisterContainer from "../container/RegisterContainer.vue";
+import LoginContainer from "../container/LoginContainer.vue";
 
 Vue.use(VueRouter);
 
@@ -9,6 +10,7 @@ export default new VueRouter({
   mode: "history",
   routes: [
     { path: "/", component: ArticlesContainer },
-    { path: "/sign_up", component: RegisterContainer }
+    { path: "/sign_up", component: RegisterContainer },
+    { path: "/sign_in", component: LoginContainer }
   ]
 });

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,10 +1,14 @@
 import Vue from "vue/dist/vue.esm.js";
 import VueRouter from "vue-router";
 import ArticlesContainer from "../container/ArticlesContainer.vue";
+import RegisterContainer from "../container/RegisterContainer.vue";
 
 Vue.use(VueRouter);
 
 export default new VueRouter({
   mode: "history",
-  routes: [{ path: "/", component: ArticlesContainer }]
+  routes: [
+    { path: "/", component: ArticlesContainer },
+    { path: "/sign_up", component: RegisterContainer }
+  ]
 });

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -2,6 +2,7 @@
 <%= stylesheet_pack_tag "app" %>
 
 <div id="app">
+  <navbar></navbar>
   <div class="container">
     <router-view></router-view>
   </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,5 +1,7 @@
 <%= javascript_pack_tag "app" %>
 <%= stylesheet_pack_tag "app" %>
+<link href="https://cdn.jsdelivr.net/npm/vuetify/dist/vuetify.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons" rel="stylesheet">
 
 <div id="app">
   <navbar></navbar>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root "homes#index"
 
+  # reload 対策
+  get "sign_up", to: "homes#index"
+
   namespace :api, format: :json do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   # reload 対策
   get "sign_up", to: "homes#index"
+  get "sign_in", to: "homes#index"
 
   namespace :api, format: :json do
     namespace :v1 do

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,9 +1,17 @@
-const { environment } = require('@rails/webpacker')
-const typescript =  require('./loaders/typescript')
-const { VueLoaderPlugin } = require('vue-loader')
-const vue = require('./loaders/vue')
+const { environment } = require("@rails/webpacker");
+const typescript = require("./loaders/typescript");
+const { VueLoaderPlugin } = require("vue-loader");
+const vue = require("./loaders/vue");
 
-environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
-environment.loaders.prepend('vue', vue)
-environment.loaders.prepend('typescript', typescript)
-module.exports = environment
+environment.plugins.prepend("VueLoaderPlugin", new VueLoaderPlugin());
+environment.loaders.prepend("vue", vue);
+environment.loaders.prepend("typescript", typescript);
+module.exports = environment;
+
+environment.config.merge({
+  resolve: {
+    alias: {
+      vue$: "vue/dist/vue.esm"
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "axios": "^0.19.0",
     "ts-loader": "^6.0.3",
     "typescript": "^3.5.2",
+    "vee-validate": "^2.2.11",
     "vue": "^2.6.10",
     "vue-loader": "^15.7.0",
     "vue-property-decorator": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "vue-loader": "^15.7.0",
     "vue-property-decorator": "^8.2.1",
     "vue-router": "^3.0.6",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "^2.6.10",
+    "vuetify": "^1.5.16"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.7.2"

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -66,11 +66,10 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
   end
 
   describe "DELETE /api/v1/auth/sign_out" do
-    subject { delete(destroy_api_v1_user_session_path, params: params, headers: headers) }
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
 
     context "ログイン済みのユーザーの情報を送ったとき" do
       let(:user) { create(:user) }
-      let(:params) { { email: user.email, password: user.password } }
       let!(:headers) { authentication_headers_for(user) }
 
       it "トークン情報が削除される" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -6901,6 +6901,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vee-validate@^2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/vee-validate/-/vee-validate-2.2.11.tgz#80b4e4b1354e6460b72b2a864a21a9298e2d71ce"
+  integrity sha512-wQMhq1cPOk+eaE+iKVyoyEUp1mczpeSvL4V3sardi9+KMgDw853kCd6v0iajdH8uUSpj319BVdXkmDlx1qWFog==
+
 vendors@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.3.tgz#a6467781abd366217c050f8202e7e50cc9eef8c0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6982,6 +6982,11 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
 
+vuetify@^1.5.16:
+  version "1.5.16"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.5.16.tgz#cc9d0199c389d64d15787ddc85ca47a28225eeee"
+  integrity sha512-yBgOsfurKQkeS+l+rrTQZ2bFk0D9ezjHhkuVM5A/yVzcg62sY2nfYaq/H++uezBWC9WYFrp/5OmSocJQcWn9Qw==
+
 watchpack@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"


### PR DESCRIPTION
## 概要
 - トップページに Qiita のようなヘッダーを追加
 - 新規登録ページの作成
 - ログインページの作成
 - ログアウト機能の実装

## イメージ
![sign_up_login](https://user-images.githubusercontent.com/10157007/60086174-9186a900-9775-11e9-9823-63de5b6970ff.gif)

## 補足
 - エラーハンドリングがかなり適当。想定していない操作をし、エラーをしても適切なエラーが表示されない。
 - 今のロジックだと 422 Error が発生する。