### PR TITLE
CSRF 機能を OFF に変更

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-  # MEMO: HTTP Client 経由で操作する場合にコメントインする
-  # protect_from_forgery with: :null_session
+  protect_from_forgery with: :null_session
 
   private
 

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,4 +1,3 @@
 class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
-  # MEMO: HTTP Client 経由で操作する場合にコメントインする
-  # protect_from_forgery with: :null_session
+  protect_from_forgery with: :null_session
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -4,4 +4,6 @@ class Api::V1::BaseApiController < ApplicationController
   alias_method :current_user, :current_api_v1_user
   alias_method :authenticate_user!, :authenticate_api_v1_user!
   alias_method :user_signed_in?, :api_v1_user_signed_in?
+
+  protect_from_forgery with: :null_session
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -30,7 +30,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require "rspec/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each {|f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.


### PR DESCRIPTION
## 概要
CSRF 脆弱性は、任意のサービスにログイン済みのユーザーが、CSRF 脆弱性を持つサイトに勝手に POST するダミーサイトにアクセスした際に、 **勝手に POST されてしまう** 脆弱性を指す。

今回、 devise-token-auth gem を使ってトークン認証を用いているので、ダミーサイト側が同一の token を準備できないので、サーバー側の CSRF 対策機構は外して問題ありません。