### PR TITLE
記事の詳細ページのフロント実装

### DIFF
--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -1,5 +1,16 @@
 <template>
-  <v-container class="item elevation-3 articles-container"></v-container>
+  <v-container v-model="article" class="item elevation-3 article-container">
+    <v-layout xs-12 class="top-info-container">
+      <span class="user-name">@{{ article.user.name }}</span>
+      <time-ago :refresh="60" :datetime="article.updated_at" locale="en" tooltip="top" long></time-ago>
+    </v-layout>
+    <v-layout>
+      <h1 class="article-title">{{ article.title }}</h1>
+    </v-layout>
+    <v-layout class="article-body-container">
+      <div id="article-body">{{ article.body }}</div>
+    </v-layout>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -16,19 +27,39 @@ export default class ArticleContainer extends Vue {
   article: any = "";
 
   async mounted(): Promise<void> {
-    await this.fetchArticle("1");
+    await this.fetchArticle(this.$route.params.id);
   }
 
   async fetchArticle(id: string): Promise<void> {
-    await axios.get(`/api/v1/articles/${id}`).then(response => {
-      this.article = response.data;
-    });
+    await axios
+      .get(`/api/v1/articles/${id}`)
+      .then(response => {
+        this.article = response.data;
+      })
+      .catch(e => {
+        // TODO: 適切な Error 表示
+        alert(e.response.statusText);
+      });
   }
 }
 </script>
 
 <style lang="scss" scoped>
-.articles-container {
-  margin-top: 2em;
+.top-info-container {
+  margin-bottom: 1em;
+}
+.article-container {
+  margin: 2em;
+}
+.article-title {
+  font-size: 2.5em;
+  line-height: 1.4;
+}
+.article-body-container {
+  margin: 2em 0;
+  font-size: 16px;
+}
+.user-name {
+  margin-right: 1em;
 }
 </style>

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-container class="item elevation-3 articles-container"></v-container>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import TimeAgo from "vue2-timeago";
+
+@Component({
+  components: {
+    TimeAgo
+  }
+})
+export default class ArticleContainer extends Vue {
+  article: any = "";
+
+  async mounted(): Promise<void> {
+    await this.fetchArticle("1");
+  }
+
+  async fetchArticle(id: string): Promise<void> {
+    await axios.get(`/api/v1/articles/${id}`).then(response => {
+      this.article = response.data;
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+}
+</style>

--- a/app/javascript/packs/container/ArticlesContainer.vue
+++ b/app/javascript/packs/container/ArticlesContainer.vue
@@ -8,7 +8,9 @@
           </v-list-tile-avatar>
 
           <v-list-tile-content>
-            <v-list-tile-title>{{ article.title }}</v-list-tile-title>
+            <v-list-tile-title class="article-title">
+              <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+            </v-list-tile-title>
             <v-list-tile-sub-title>
               by {{ article.user.name }}
               <time-ago
@@ -57,5 +59,18 @@ export default class ArticlesContainer extends Vue {
 <style lang="scss" scoped>
 .articles-container {
   margin-top: 2em;
+  .article-title {
+    a {
+      color: #000;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:visited {
+      color: #777;
+    }
+  }
 }
 </style>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -1,6 +1,7 @@
 import Vue from "vue/dist/vue.esm.js";
 import VueRouter from "vue-router";
 import ArticlesContainer from "../container/ArticlesContainer.vue";
+import ArticleContainer from "../container/ArticleContainer.vue";
 import RegisterContainer from "../container/RegisterContainer.vue";
 import LoginContainer from "../container/LoginContainer.vue";
 import EditArticleContainer from "../container/EditArticleContainer.vue";
@@ -13,6 +14,7 @@ export default new VueRouter({
     { path: "/", component: ArticlesContainer },
     { path: "/sign_up", component: RegisterContainer },
     { path: "/sign_in", component: LoginContainer },
-    { path: "/articles/new", component: EditArticleContainer }
+    { path: "/articles/new", component: EditArticleContainer },
+    { path: "/articles/:id", component: ArticleContainer }
   ]
 });

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -15,6 +15,6 @@ export default new VueRouter({
     { path: "/sign_up", component: RegisterContainer },
     { path: "/sign_in", component: LoginContainer },
     { path: "/articles/new", component: EditArticleContainer },
-    { path: "/articles/:id", component: ArticleContainer }
+    { path: "/articles/:id", component: ArticleContainer, name: "article" }
   ]
 });

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body
+  attributes :id, :title, :body, :updated_at
   belongs_to :user
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "sign_up", to: "homes#index"
   get "sign_in", to: "homes#index"
   get "articles/new", to: "homes#index"
+  get "articles/:id", to: "homes#index"
 
   namespace :api, format: :json do
     namespace :v1 do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Articles", type: :request do
           expect(res["id"]).to eq article.id
           expect(res["title"]).to eq article.title
           expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
           expect(res["user"]["id"]).to eq article.user.id
           expect(res["user"].keys).to eq ["id", "name", "email"]
         end


### PR DESCRIPTION
## 概要
 - 記事の詳細ページを作成
 - 記事一覧から詳細ページへ飛べるように修正

## イメージ
![article-index](https://user-images.githubusercontent.com/10157007/60168907-a54b1180-9840-11e9-8d2c-afc5057c4c4e.gif)
