### PR TITLE
Markdown を Syntax Highlight で表示するように修正

### DIFF
--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Router from "./router/router";
 import Header from "./container/Header.vue";
 import Vuetify from "vuetify";
+import "highlight.js/styles/monokai.css";
 
 Vue.use(Vuetify);
 

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -8,7 +8,7 @@
       <h1 class="article-title">{{ article.title }}</h1>
     </v-layout>
     <v-layout class="article-body-container">
-      <div id="article-body">{{ article.body }}</div>
+      <div id="article-body" v-html="compiledMarkdown"></div>
     </v-layout>
   </v-container>
 </template>
@@ -17,6 +17,7 @@
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import TimeAgo from "vue2-timeago";
+import marked from "marked";
 
 @Component({
   components: {
@@ -28,6 +29,10 @@ export default class ArticleContainer extends Vue {
 
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
+  }
+
+  get compiledMarkdown() {
+    return marked(this.article.body);
   }
 
   async fetchArticle(id: string): Promise<void> {
@@ -49,7 +54,7 @@ export default class ArticleContainer extends Vue {
   margin-bottom: 1em;
 }
 .article-container {
-  margin: 2em;
+  margin-top: 2em;
 }
 .article-title {
   font-size: 2.5em;

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -18,6 +18,7 @@ import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
 import TimeAgo from "vue2-timeago";
 import marked from "marked";
+import hljs from "highlight.js";
 
 @Component({
   components: {
@@ -29,6 +30,37 @@ export default class ArticleContainer extends Vue {
 
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
+  }
+
+  async created(): Promise<void> {
+    // Add 'hljs' class to code tag
+    const renderer = new marked.Renderer();
+    renderer.code = function(code, language) {
+      return (
+        "<pre" +
+        '><code class="hljs">' +
+        hljs.highlightAuto(code).value +
+        "</code></pre>"
+      );
+    };
+
+    marked.setOptions({
+      renderer: renderer,
+      tables: true,
+      sanitize: true,
+      langPrefix: "",
+      highlight: function(code, lang) {
+        if (!lang || lang == "default") {
+          return hljs.highlightAuto(code, [lang]).value;
+        } else {
+          try {
+            return hljs.highlight(lang, code, true).value;
+          } catch (e) {
+            // Do nonthing!
+          }
+        }
+      }
+    });
   }
 
   get compiledMarkdown() {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "axios": "^0.19.0",
+    "highlight.js": "^9.15.8",
     "marked": "^0.6.2",
     "ts-loader": "^6.0.3",
     "typescript": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "axios": "^0.19.0",
+    "marked": "^0.6.2",
     "ts-loader": "^6.0.3",
     "typescript": "^3.5.2",
     "vee-validate": "^2.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,6 +4440,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
+  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3585,6 +3585,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight.js@^9.15.8:
+  version "9.15.8"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.8.tgz#f344fda123f36f1a65490e932cf90569e4999971"
+  integrity sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
## 概要
テキスト本文を確認する際、Markdown を Syntax highlight して表示するように調整

## イメージ
<img width="928" alt="スクリーンショット 2019-06-26 19 58 15" src="https://user-images.githubusercontent.com/10157007/60174775-c31e7380-984c-11e9-835a-7cd7216b4364.png">

## 使用した library
 - [marked.js](https://github.com/markedjs/marked)
 - [highlight.js](https://github.com/highlightjs/highlight.js/)