### PR TITLE
記事の下書き機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,12 +4,12 @@ module Api::V1
     before_action :set_article, only: [:update, :destroy]
 
     def index
-      articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article
     end
 
@@ -35,7 +35,7 @@ module Api::V1
       end
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,10 +8,13 @@
 #  user_id    :bigint
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  status     :string(255)      default("draft")
 #
 
 class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   belongs_to :user
+
+  enum status: { draft: "draft", published: "published" }
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user
 end

--- a/db/migrate/20190626172029_add_status_to_articles.rb
+++ b/db/migrate/20190626172029_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_20_095748) do
+ActiveRecord::Schema.define(version: 2019_06_26_172029) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2019_06_20_095748) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -8,6 +8,7 @@
 #  user_id    :bigint
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  status     :string(255)      default("draft")
 #
 
 FactoryBot.define do

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -15,6 +15,15 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
+    status { :published }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,6 +8,7 @@
 #  user_id    :bigint
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  status     :string(255)      default("draft")
 #
 
 require "rails_helper"

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article) }
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
 
-    it "記事の一覧が取得できる(更新順)" do
+    before { create(:article, :draft) }
+
+    it "公開済みの記事の一覧が取得できる(更新順)" do
       subject
 
       res = JSON.parse(response.body)
@@ -26,23 +28,35 @@ RSpec.describe "Articles", type: :request do
   describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定した id の記事が存在する場合" do
-      let(:article) { create(:article) }
+    context "指定した id の記事が存在し" do
       let(:article_id) { article.id }
 
-      it "任意の記事の値が取得できる" do
-        subject
+      context "対象の記事が公開中であるとき" do
+        let(:article) { create(:article, :published) }
 
-        res = JSON.parse(response.body)
+        it "記事のデータを取得できる" do
+          subject
 
-        aggregate_failures do
-          expect(response).to have_http_status(:ok)
-          expect(res["id"]).to eq article.id
-          expect(res["title"]).to eq article.title
-          expect(res["body"]).to eq article.body
-          expect(res["updated_at"]).to be_present
-          expect(res["user"]["id"]).to eq article.user.id
-          expect(res["user"].keys).to eq ["id", "name", "email"]
+          res = JSON.parse(response.body)
+
+          aggregate_failures do
+            expect(response).to have_http_status(:ok)
+            expect(res["id"]).to eq article.id
+            expect(res["title"]).to eq article.title
+            expect(res["body"]).to eq article.body
+            expect(res["status"]).to eq article.status
+            expect(res["updated_at"]).to be_present
+            expect(res["user"]["id"]).to eq article.user.id
+            expect(res["user"].keys).to eq ["id", "name", "email"]
+          end
+        end
+      end
+
+      context "対象の記事が下書き状態であるとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
         end
       end
     end
@@ -60,13 +74,39 @@ RSpec.describe "Articles", type: :request do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:current_user) { create(:user) }
-    let(:params) { { article: attributes_for(:article) } }
     let(:headers) { authentication_headers_for(current_user) }
 
-    it "記事のレコードが作成できる" do
-      aggregate_failures do
-        expect { subject }.to change { Article.count }.by(1)
-        expect(response).to have_http_status(:ok)
+    context "公開指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
+
+      it "公開記事が作成できる" do
+        aggregate_failures do
+          expect { subject }.to change { Article.count }.by(1)
+          res = JSON.parse(response.body)
+          expect(res["status"]).to eq "published"
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context "下書き指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+
+      it "下書き記事が作成できる" do
+        aggregate_failures do
+          expect { subject }.to change { Article.count }.by(1)
+          res = JSON.parse(response.body)
+          expect(res["status"]).to eq "draft"
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context "でたらめな指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, status: :foo) } }
+
+      it "Argumennt Error する" do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
   end
@@ -75,16 +115,17 @@ RSpec.describe "Articles", type: :request do
     subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:current_user) { create(:user) }
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:headers) { authentication_headers_for(current_user) }
 
     context "自分が所持している記事のレコードを更新しようとするとき" do
-      let!(:article) { create(:article, user: current_user) }
+      let!(:article) { create(:article, :draft, user: current_user) }
 
       it "記事を更新できる" do
         aggregate_failures do
           expect { subject }.to change { Article.find(article.id).title }.from(article.title).to(params[:article][:title]) &
-                                change { Article.find(article.id).body }.from(article.body).to(params[:article][:body])
+                                change { Article.find(article.id).body }.from(article.body).to(params[:article][:body]) &
+                                change { Article.find(article.id).status }.from(article.status).to(params[:article][:status].to_s)
           expect(response).to have_http_status(:ok)
         end
       end


### PR DESCRIPTION
## 概要
 - 記事の下書き機能の実装
   - 記事の一覧には下書き記事は表示されないように調整
   - 記事の詳細は記事の所持者にかかわらず、公開された状態でない限り誰も見れないように調整
   - 記事の作成 / 更新時に記事の公開のステータスを任意の値に変更できるように変更
 