### PR TITLE
下書き機能の実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!, only: [:index]
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -9,7 +9,7 @@ module Api::V1
 
     def show
       article = current_user.articles.draft.find(params[:id])
-      render json: article
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
   end
 end

--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,10 +1,15 @@
 module Api::V1
   class Articles::DraftsController < BaseApiController
-    before_action :authenticate_user!, only: [:index]
+    before_action :authenticate_user!, only: [:index, :show]
 
     def index
       articles = current_user.articles.draft.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article
     end
   end
 end

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -107,13 +107,13 @@ export default class ArticleContainer extends Vue {
   }
 
   async confirmDeleteArticle(): Promise<void> {
-    const result = confirm("この記事を削除してもよろしいですか？")
+    const result = confirm("この記事を削除してもよろしいですか？");
 
     if (result) {
       await axios
         .delete(`/api/v1/articles/${this.article.id}`, headers)
         .then(_response => {
-          Router.push("/")
+          Router.push("/");
         })
         .catch(e => {
           // TODO: 適切な Error 表示

--- a/app/javascript/packs/container/DraftArticlesContainer.vue
+++ b/app/javascript/packs/container/DraftArticlesContainer.vue
@@ -1,0 +1,92 @@
+<template>
+  <v-container class="item elevation-3 articles-container">
+    <h2>下書き一覧</h2>
+    <v-list two-line>
+      <template v-for="(article, index) in articles">
+        <v-list-tile :key="article.title" avatar>
+          <v-list-tile-avatar>
+            <img :src="article.avatar" />
+          </v-list-tile-avatar>
+
+          <v-list-tile-content>
+            <v-list-tile-title class="article-title">
+              <a @click="moveToEditPage(article.id)">{{ article.title }}</a>
+            </v-list-tile-title>
+            <v-list-tile-sub-title>
+              by {{ article.user.name }}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        <v-divider :key="index"></v-divider>
+      </template>
+    </v-list>
+  </v-container>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import TimeAgo from "vue2-timeago";
+import Router from "../router/router";
+
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+
+@Component({
+  components: {
+    TimeAgo
+  }
+})
+export default class DraftArticlesContainer extends Vue {
+  articles: string[] = [];
+
+  async mounted(): Promise<void> {
+    await this.fetchArticles();
+  }
+
+  async fetchArticles(): Promise<void> {
+    await axios.get("/api/v1/articles/drafts", headers).then(response => {
+      response.data.map((article: any) => {
+        this.articles.push(article);
+      });
+    });
+  }
+
+  moveToEditPage(id: string) {
+    Router.push(`/articles/drafts/${id}/edit`);
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+  .article-title {
+    a {
+      color: #000;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:visited {
+      color: #777;
+    }
+  }
+}
+</style>

--- a/app/javascript/packs/container/EditDraftArticleContainer.vue
+++ b/app/javascript/packs/container/EditDraftArticleContainer.vue
@@ -46,13 +46,12 @@ const headers = {
 };
 
 @Component
-export default class ArticlesContainer extends Vue {
+export default class EditDraftArticleContainer extends Vue {
   id: string = "";
   title: string = "";
   body: string = "";
 
   async mounted(): Promise<void> {
-    // only update
     if (this.$route.params.id) {
       await this.fetchArticle(this.$route.params.id);
     }
@@ -88,7 +87,7 @@ export default class ArticlesContainer extends Vue {
 
   async fetchArticle(id: string): Promise<void> {
     await axios
-      .get(`/api/v1/articles/${id}`)
+      .get(`/api/v1/articles/drafts/${id}`, headers)
       .then(response => {
         this.id = response.data.id;
         this.title = response.data.title;
@@ -117,7 +116,11 @@ export default class ArticlesContainer extends Vue {
       await axios
         .patch(`/api/v1/articles/${this.id}`, params, headers)
         .then(_response => {
-          Router.push("/articles/drafts");
+          if (status == Statuses["published"]) {
+            Router.push("/");
+          } else {
+            Router.push("/articles/drafts");
+          }
         })
         .catch(e => {
           // TODO: 適切な Error 表示
@@ -128,7 +131,11 @@ export default class ArticlesContainer extends Vue {
       await axios
         .post("/api/v1/articles", params, headers)
         .then(_response => {
-          Router.push("/articles/drafts");
+          if (status == Statuses["published"]) {
+            Router.push("/");
+          } else {
+            Router.push("/articles/drafts");
+          }
         })
         .catch(e => {
           // TODO: 適切な Error 表示

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -101,7 +101,7 @@ export default class Header extends Vue {
   }
 
   moveToDrafts(): void {
-    alert("下書きページへ移動");
+    Router.push("/articles/drafts");
   }
 
   private refresh(): void {

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -4,17 +4,25 @@
       <v-toolbar-title class="white--text font-weight-bold">Qiita</v-toolbar-title>
     </router-link>
 
-    <!-- <v-btn icon>
-      <v-icon>search</v-icon>
-    </v-btn>-->
-
     <v-spacer></v-spacer>
 
     <div v-if="isLoggedIn">
       <router-link to="/articles/new" class="header-link">
         <v-btn flat class="post font-weight-bold">投稿する</v-btn>
       </router-link>
-      <v-btn flat @click="logout" class="white--text font-weight-bold">ログアウト</v-btn>
+      <v-menu bottom left min-width="120">
+        <template v-slot:activator="{ on }">
+          <v-btn dark icon v-on="on">
+            <v-icon>more_vert</v-icon>
+          </v-btn>
+        </template>
+
+        <v-list>
+          <v-list-tile v-for="(menu, i) in menus" :key="i" @click="undefined">
+            <v-list-tile-title @click="menu.click">{{ menu.title }}</v-list-tile-title>
+          </v-list-tile>
+        </v-list>
+      </v-menu>
     </div>
     <div v-else>
       <router-link to="/sign_up" class="header-link">
@@ -45,6 +53,32 @@ const headers = {
 @Component
 export default class Header extends Vue {
   isLoggedIn: boolean = !!localStorage.getItem("access-token");
+  items: any = [
+    { title: "Menu" },
+    { title: "Menu" },
+    { title: "Menu" },
+    { title: "Menu" }
+  ];
+  menus: any = [
+    {
+      title: "マイページ",
+      click: () => {
+        this.moveToMyPage();
+      }
+    },
+    {
+      title: "下書き一覧",
+      click: () => {
+        this.moveToDrafts();
+      }
+    },
+    {
+      title: "ログアウト",
+      click: () => {
+        this.logout();
+      }
+    }
+  ];
 
   async logout(): Promise<void> {
     await axios
@@ -60,6 +94,14 @@ export default class Header extends Vue {
         // ログアウトはしてしまっている状態なのですべてリセットする
         this.refresh();
       });
+  }
+
+  moveToMyPage(): void {
+    alert("マイページへ移動");
+  }
+
+  moveToDrafts(): void {
+    alert("下書きページへ移動");
   }
 
   private refresh(): void {

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -5,6 +5,8 @@ import ArticleContainer from "../container/ArticleContainer.vue";
 import RegisterContainer from "../container/RegisterContainer.vue";
 import LoginContainer from "../container/LoginContainer.vue";
 import EditArticleContainer from "../container/EditArticleContainer.vue";
+import DraftArticlesContainer from "../container/DraftArticlesContainer.vue";
+import EditDraftArticleContainer from "../container/EditDraftArticleContainer.vue";
 
 Vue.use(VueRouter);
 
@@ -15,7 +17,9 @@ export default new VueRouter({
     { path: "/sign_up", component: RegisterContainer },
     { path: "/sign_in", component: LoginContainer },
     { path: "/articles/new", component: EditArticleContainer },
+    { path: "/articles/drafts", component: DraftArticlesContainer },
     { path: "/articles/:id/edit", component: EditArticleContainer },
+    { path: "/articles/drafts/:id/edit", component: EditDraftArticleContainer },
     { path: "/articles/:id", component: ArticleContainer, name: "article" }
   ]
 });

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
   attributes :id, :title, :updated_at
-  belongs_to :user
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :status, :updated_at
-  belongs_to :user
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   get "sign_up", to: "homes#index"
   get "sign_in", to: "homes#index"
   get "articles/new", to: "homes#index"
+  get "articles/draft", to: "homes#index"
+  get "articles/drafts/:id/edit", to: "homes#index"
   get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "homes#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
         sessions: "api/v1/auth/sessions",
       }
+      namespace :articles do
+        resources :drafts, only: [:index]
+      end
       resources :articles
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         sessions: "api/v1/auth/sessions",
       }
       namespace :articles do
-        resources :drafts, only: [:index]
+        resources :drafts, only: [:index, :show]
       end
       resources :articles
     end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -23,4 +23,44 @@ RSpec.describe "Articles::Drafts", type: :request do
       end
     end
   end
+
+  describe "GET /articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { authentication_headers_for(current_user) }
+
+    context "指定した id の記事が存在し" do
+      let(:article_id) { article.id }
+
+      context "対象の記事が自身の下書きであるとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+
+        it "記事のデータを取得できる" do
+          subject
+
+          res = JSON.parse(response.body)
+
+          aggregate_failures do
+            expect(response).to have_http_status(:ok)
+            expect(res["id"]).to eq article.id
+            expect(res["title"]).to eq article.title
+            expect(res["body"]).to eq article.body
+            expect(res["status"]).to eq article.status
+            expect(res["updated_at"]).to be_present
+            expect(res["user"]["id"]).to eq article.user.id
+            expect(res["user"].keys).to eq ["id", "name", "email"]
+          end
+        end
+      end
+
+      context "対象の記事が他のユーザーの下書きであるとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { authentication_headers_for(current_user) }
+
+    let!(:article1) { create(:article, :draft, user: current_user) }
+    let!(:article2) { create(:article, :draft) }
+
+    it "自分が書いた下書き記事の一覧が取得できる" do
+      subject
+
+      res = JSON.parse(response.body)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 1
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
### API
 - 下書き一覧, 詳細の API および テストを実装

### Front
 - ヘッダーから下書き一覧ページに遷移できるように調整
 - 下書き一覧 / 下書き編集ページの実装 / つなぎこみ

## イメージ
![draft-test](https://user-images.githubusercontent.com/10157007/60905263-a9027d80-a2af-11e9-9a30-ff2ba007bb16.gif)

## 補足
 - フロントエンドはコンテンツが重複しまくっていたりと、かなり適当な実装なので、あまり参考にはしないでください。header の情報も Vuex を使っていないせいで、だいぶ散らかってきています。