### PR TITLE
マイページの追加

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -3,8 +3,8 @@ module Api::V1
     before_action :authenticate_user!, only: [:index]
 
     def index
-      articles = current_user.articles.published.order(updated_at: :desc)
-      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+      articles = current_user.articles.published.order(created_at: :desc)
+      render json: articles, each_serializer: Api::V1::Current::ArticlePreviewSerializer
     end
   end
 end

--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:index]
+
+    def index
+      articles = current_user.articles.published.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -97,7 +97,7 @@ export default class Header extends Vue {
   }
 
   moveToMyPage(): void {
-    alert("マイページへ移動");
+    Router.push("/mypage");
   }
 
   moveToDrafts(): void {

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -16,11 +16,12 @@
               by {{ article.user.name }}
               <time-ago
                 :refresh="60"
-                :datetime="article.updated_at"
+                :datetime="article.created_at"
                 locale="en"
                 tooltip="right"
                 long
               ></time-ago>
+              <span>に投稿</span>
             </v-list-tile-sub-title>
           </v-list-tile-content>
         </v-list-tile>

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -1,0 +1,88 @@
+<template>
+  <v-container class="item elevation-3 articles-container">
+    <h2>最近書いた記事</h2>
+    <v-list two-line>
+      <template v-for="(article, index) in articles">
+        <v-list-tile :key="article.title" avatar>
+          <v-list-tile-avatar>
+            <img :src="article.avatar" />
+          </v-list-tile-avatar>
+
+          <v-list-tile-content>
+            <v-list-tile-title class="article-title">
+              <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+            </v-list-tile-title>
+            <v-list-tile-sub-title>
+              by {{ article.user.name }}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        <v-divider :key="index"></v-divider>
+      </template>
+    </v-list>
+  </v-container>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import TimeAgo from "vue2-timeago";
+import Router from "../router/router";
+
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+
+@Component({
+  components: {
+    TimeAgo
+  }
+})
+export default class MyPageContainer extends Vue {
+  articles: string[] = [];
+
+  async mounted(): Promise<void> {
+    await this.fetchArticles();
+  }
+
+  async fetchArticles(): Promise<void> {
+    await axios.get("/api/v1/current/articles", headers).then(response => {
+      response.data.map((article: any) => {
+        this.articles.push(article);
+      });
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+  .article-title {
+    a {
+      color: #000;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:visited {
+      color: #777;
+    }
+  }
+}
+</style>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -7,6 +7,7 @@ import LoginContainer from "../container/LoginContainer.vue";
 import EditArticleContainer from "../container/EditArticleContainer.vue";
 import DraftArticlesContainer from "../container/DraftArticlesContainer.vue";
 import EditDraftArticleContainer from "../container/EditDraftArticleContainer.vue";
+import MyPageContainer from "../container/MyPageContainer.vue";
 
 Vue.use(VueRouter);
 
@@ -20,6 +21,7 @@ export default new VueRouter({
     { path: "/articles/drafts", component: DraftArticlesContainer },
     { path: "/articles/:id/edit", component: EditArticleContainer },
     { path: "/articles/drafts/:id/edit", component: EditDraftArticleContainer },
-    { path: "/articles/:id", component: ArticleContainer, name: "article" }
+    { path: "/articles/:id", component: ArticleContainer, name: "article" },
+    { path: "/mypage", component: MyPageContainer }
   ]
 });

--- a/app/serializers/api/v1/current/article_preview_serializer.rb
+++ b/app/serializers/api/v1/current/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::Current::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :created_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get "articles/drafts/:id/edit", to: "homes#index"
   get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "homes#index"
-  get "articles/mypage", to: "homes#index"
+  get "mypage", to: "homes#index"
 
   namespace :api, format: :json do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
         resources :drafts, only: [:index, :show]
       end
       resources :articles
+      namespace :current do
+        resources :articles, only: [:index]
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "articles/drafts/:id/edit", to: "homes#index"
   get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "homes#index"
+  get "articles/mypage", to: "homes#index"
 
   namespace :api, format: :json do
     namespace :v1 do

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Articles::Drafts", type: :request do
       aggregate_failures do
         expect(response).to have_http_status(:ok)
         expect(res.length).to eq 1
+        expect(res[0]["id"]).to eq article1.id
         expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "Current::Articles", type: :request do
     let(:current_user) { create(:user) }
     let(:headers) { authentication_headers_for(current_user) }
 
-    let!(:article) { create(:article, :published, user: current_user) }
+    let!(:article1) { create(:article, :published, user: current_user, created_at: 10.days.ago, updated_at: 1.day.ago) }
+    let!(:article2) { create(:article, :published, user: current_user, created_at: 3.days.ago, updated_at: 2.days.ago) }
 
     before do
       create(:article, :draft, user: current_user)
@@ -21,9 +22,9 @@ RSpec.describe "Current::Articles", type: :request do
 
       aggregate_failures do
         expect(response).to have_http_status(:ok)
-        expect(res.length).to eq 1
-        expect(res[0]["id"]).to eq article.id
-        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res.length).to eq 2
+        expect(res.map {|d| d["id"] }).to eq [article2.id, article1.id]
+        expect(res[0].keys).to eq ["id", "title", "created_at", "user"]
         expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       end
     end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:headers) { authentication_headers_for(current_user) }
+
+    let!(:article) { create(:article, :published, user: current_user) }
+
+    before do
+      create(:article, :draft, user: current_user)
+      create(:article, :published)
+    end
+
+    it "自分が書いた公開記事の一覧が取得できる" do
+      subject
+
+      res = JSON.parse(response.body)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 1
+        expect(res[0]["id"]).to eq article.id
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
### API
 - マイページ用の API / テストを実装
   - 自分で書いた公開記事を公開順で並べる
     - 略式で、 `created_at` で並べているが、実際は status が公開になったタイミングで `published_at` （今はこの column 自体存在しない）を更新し、その順で並べるのが正しい。
   - 下書き記事についてはマイページでは表示させず、下書き記事一覧で表示。

### Front
 - 自分で書いた記事を一覧できるようマイページを修正
 - 記事の作成日時を表示

## イメージ
<img width="1079" alt="スクリーンショット 2019-07-10 2 11 35" src="https://user-images.githubusercontent.com/10157007/60910111-e28cb600-a2ba-11e9-87e7-15878c629061.png">
